### PR TITLE
Refactor downloader scripts

### DIFF
--- a/dont_download.sh
+++ b/dont_download.sh
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
+
+# Checks if a binary is present on the local system
+exit_if_binary_not_installed() {
+  for binary in "$@"; do
+    command -v "$binary" >/dev/null 2>&1 || {
+      echo >&2 "Script requires '$binary' command-line utility to be installed on your local machine. Aborting..."
+      exit 1
+    }
+  done
+}
+
 set -euo pipefail
 export DOWNLOADER_LAUNCHER_PATH="${DOWNLOADER_LAUNCHER_PATH:-${0}}"
 export COMMIT=d11ef18
+
+exit_if_binary_not_installed "uudecode" "xzcat" "python3"
+
 uudecode -o - "${0}" | xzcat -d -c > "/tmp/dont_download.zip"
 chmod a+x "/tmp/dont_download.zip"
 "/tmp/dont_download.zip" "${1:-}"

--- a/downloader.sh
+++ b/downloader.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2021-2022 José Manuel Barroso Galindo <theypsilon@gmail.com>
 
 # This program is free software: you can redistribute it and/or modify
@@ -19,26 +19,40 @@
 
 set -euo pipefail
 
+export CACERT_PATH="/etc/ssl/certs/cacert.pem" # Default path for cacert.pem in MiSTer distro
+
+# download_file: downloads <url> to <file>
 download_file() {
     local DOWNLOAD_PATH="${1}"
     local DOWNLOAD_URL="${2}"
+
+    # Loop: 1 time + 60 retries fixing SSL = 61 attempts
     for (( COUNTER=0; COUNTER<=60; COUNTER+=1 )); do
+
+        # The first time do not sleep.
+        # For every other time, sleep for 1 second. This is to avoid hitting the server too hard.
         if [ ${COUNTER} -ge 1 ] ; then
+            echo "Before rertying #${COUNTER}: wait a second..."
             sleep 1s
         fi
-        set +e
-        curl ${CURL_SSL:-} --fail --location -o "${DOWNLOAD_PATH}" "${DOWNLOAD_URL}" &> /dev/null
-        local CMD_RET=$?
-        set -e
 
+        set +e # Disable errexit so we can catch the return code from curl, if it fails.
+        # --fail: Fail silently (no output at all) on server errors.
+        # --location: Follow any redirections.
+        # --output: Write the output to a file.
+        curl ${CURL_SSL:-} --fail --location --output "${DOWNLOAD_PATH}" "${DOWNLOAD_URL}" &> /dev/null
+        local CMD_RET=$?
+        set -e # Enable errexit, now that we've caught the return code from curl.
+
+        # Decide what to do based on the return code from curl.
         case ${CMD_RET} in
             0)
                 export CURL_SSL="${CURL_SSL:-}"
                 return
                 ;;
             60)
-                if [ -f /etc/ssl/certs/cacert.pem ] ; then
-                    export CURL_SSL="--cacert /etc/ssl/certs/cacert.pem"
+                if [ -f ${CACERT_PATH} ] ; then
+                    export CURL_SSL="--cacert ${CACERT_PATH}"
                     continue
                 fi
 
@@ -56,13 +70,13 @@ download_file() {
                     fi
                     [ "${RO_ROOT}" == "true" ] && mount / -o remount,rw
                     rm /etc/ssl/certs/* 2> /dev/null || true
-                    echo
-                    echo "Installing cacert.pem from https://curl.se"
-                    curl --insecure --location -o /etc/ssl/certs/cacert.pem "https://curl.se/ca/cacert.pem"
+                    echo; echo "Installing cacert.pem from https://curl.se"
+                    curl --insecure --location -o ${CACERT_PATH} "https://curl.se/ca/cacert.pem"
                     sync
                     [ "${RO_ROOT}" == "true" ] && mount / -o remount,ro
                     echo
-                    export CURL_SSL="--cacert /etc/ssl/certs/cacert.pem"
+                    echo "Done. SSL certificates have been fixed."
+                    export CURL_SSL="--cacert ${CACERT_PATH}"
                     continue
                 fi
 
@@ -77,7 +91,6 @@ download_file() {
                     echo
                     echo "WARNING! Connection is insecure."
                     export CURL_SSL="--insecure"
-                    sleep 5s
                     echo
                     continue
                 fi
@@ -85,6 +98,13 @@ download_file() {
                 echo "No secure connection is possible without fixing the certificates."
                 exit 1
                 ;;
+            # Command not found, Please install curl
+            127)
+                echo "curl is not installed. File a bug report at 'https://github.com/MiSTer-devel/Distribution_MiSTer'"
+                exit 1
+                ;;
+
+             # If curl returns a non-zero return code (except 60, that means certs have issues), then exit.
             *)
                 echo "No Internet connection, please try again later."
                 exit 1
@@ -101,12 +121,15 @@ echo
 
 SCRIPT_PATH="/tmp/downloader.sh"
 
+# Delete the downloader script if it already exists.
 rm ${SCRIPT_PATH} 2> /dev/null || true
 
+# Download the 'dont_download.sh' script.
 download_file "${SCRIPT_PATH}" "https://raw.githubusercontent.com/MiSTer-devel/Downloader_MiSTer/main/dont_download.sh"
 
 chmod +x "${SCRIPT_PATH}"
 
+# Run the 'dont_download.sh' script.
 export DOWNLOADER_LAUNCHER_PATH="${BASH_SOURCE[0]}"
 
 if ! "${SCRIPT_PATH}" ; then


### PR DESCRIPTION
While I was reading the scripts (to understand how they work) I've started putting some comments at some places. Later I've started introducing some "echo" statement as well. Also, I've noticed `/etc/ssl/certs/cacert.pem` is used in many places as a string literal, so I've created a constant to pass this around. In the end, I've tried to run this outside of MiSTer and I got hit by some missing binaries, so I added a function to check for those.

Nothing significant here, mostly cosmetic changes I would say.
Feel free to approve or reject this.