### PR TITLE
Add support for persistent Linux config files

### DIFF
--- a/src/downloader/constants.py
+++ b/src/downloader/constants.py
@@ -64,6 +64,15 @@ FILE_downloader_launcher_script = 'Scripts/downloader.sh'
 # Linux Update files
 FILE_MiSTer_version = '/MiSTer.version'
 FILE_Linux_7z = '/media/fat/linux/7za'
+FILE_Linux_user_files = [
+    # source -> destination
+    ('/media/fat/linux/hostname', '/etc/hostname'),
+    ('/media/fat/linux/hosts', '/etc/hosts'),
+    ('/media/fat/linux/interfaces', '/etc/network/interfaces'),
+    ('/media/fat/linux/resolv.conf', '/etc/resolv.conf'),
+    ('/media/fat/linux/dhcpd.conf', '/etc/dhcpd.conf'),
+    ('/media/fat/linux/fstab', '/etc/fstab'),
+]
 
 # Reboot files
 FILE_downloader_needs_reboot_after_linux_update = '/tmp/downloader_needs_reboot_after_linux_update'

--- a/src/downloader/linux_updater.py
+++ b/src/downloader/linux_updater.py
@@ -213,8 +213,8 @@ class LinuxUpdater:
             try:
                 self._file_system.copy_file(source, image_destination)
             except Exception as e:
-                self._logger.print('ERROR!')
-                self._logger.print('Could not install "%s" to "%s": %s' % (source, destination, str(e)))
+                self._logger.print('ERROR! Could not be installed.')
+                self._logger.debug('Could not install "%s" to "%s": %s' % (source, destination, str(e)))
             else:
                 self._logger.print('OK!')
         self._logger.print()

--- a/src/downloader/linux_updater.py
+++ b/src/downloader/linux_updater.py
@@ -156,6 +156,11 @@ class LinuxUpdater:
             self._logger.print()
             return
 
+        if len(self._user_files) > 0:
+            restore_error = self._restore_user_files()
+            if restore_error:
+                return
+
         self._logger.print()
         self._logger.print("======================================================================================")
         self._logger.print("Hold your breath: updating the Kernel, the Linux filesystem, the bootloader and stuff.")
@@ -186,25 +191,22 @@ class LinuxUpdater:
             self._logger.print('ERROR! Something went wrong during the Linux update, try again later.')
             self._logger.print('Error code: %d' % result.returncode)
             self._logger.print()
-            return
 
-        if len(self._user_files) > 0:
-            self._restore_user_files()
-
-    def _restore_user_files(self):
+    def _restore_user_files(self) -> bool:
         temp_dir = tempfile.mkdtemp()
         self._logger.debug('Created temporary directory for image: %s' % temp_dir)
 
-        mount_cmd = 'mount -t ext4 /media/fat/linux/linux.img {0}'.format(temp_dir)
-        self._logger.debug('Mounting Linux image with command: %s' % mount_cmd)
+        mount_cmd = 'mount -t ext4 /media/fat/linux.update/files/linux/linux.img {0}'.format(temp_dir)
+        self._logger.debug('Mounting temporary Linux image with command: %s' % mount_cmd)
         result = subprocess.run(mount_cmd, shell=True, stderr=subprocess.STDOUT)
 
         if result.returncode != 0:
             self._logger.print('ERROR! Could not mount updated Linux image, try again later.')
             self._logger.print('Error code: %d' % result.returncode)
             self._logger.print()
-            return
+            return False
 
+        copy_error = False
         self._logger.print('Restoring user Linux configuration files:')
         for source, destination in self._user_files:
             image_destination = temp_dir + destination
@@ -214,7 +216,9 @@ class LinuxUpdater:
                 self._file_system.copy(source, image_destination)
             except Exception as e:
                 self._logger.print('ERROR! Could not be installed.')
-                self._logger.debug('Could not install "%s" to "%s": %s' % (source, destination, str(e)))
+                self._logger.debug('Could not copy "%s" to "%s": %s' % (source, destination, str(e)))
+                copy_error = True
+                break
             else:
                 self._logger.print('OK!')
         self._logger.print()
@@ -224,9 +228,17 @@ class LinuxUpdater:
         result = subprocess.run(unmount_cmd, shell=True, stderr=subprocess.STDOUT)
 
         if result.returncode != 0:
-            self._logger.print('WARNING! Could not unmount updated Linux image.')
+            self._logger.print('ERROR! Could not unmount updated temporary Linux image.')
             self._logger.print('Error code: %d' % result.returncode)
             self._logger.print()
+            return False
+
+        if copy_error:
+            self._logger.print('ERROR! Could not restore user Linux configuration files.')
+            self._logger.print()
+            return False
+
+        return True
 
     def needs_reboot(self):
         return self._file_system.is_file(FILE_downloader_needs_reboot_after_linux_update)


### PR DESCRIPTION
This is a proof of concept as discussed. I've been pretty liberal adding TODO comments that would need to be clarified before it's considered.

The basic idea is:
- User keeps a copy of certain config files they have customised in the linux folder on the SD card
- During linux update, downloader checks if these files exist
- If they exist, after the linux.img file has been copied over and update is finalised, mount the .img and copy the user files into it

Simple enough.

I've picked out these files:
- /etc/hostname
- /etc/hosts
- /etc/network/interfaces
- /etc/resolv.conf
- /etc/dhcpd.conf
- /etc/fstab

I think the risk here is very low, as it's purely opt in. There's a question of whether or not to handle official updates to these files. Notify the user? Attempt to merge? Ignore it? I'm leaning with ignore it personally, as the other options add a lot of complexity. I can't imagine these files will change much anyway.

I don't know how this change might affect your PC downloader app if at all.