### PR TITLE
Fix restore_user_files error checking

### DIFF
--- a/src/downloader/linux_updater.py
+++ b/src/downloader/linux_updater.py
@@ -157,8 +157,8 @@ class LinuxUpdater:
             return
 
         if len(self._user_files) > 0:
-            restore_error = self._restore_user_files()
-            if restore_error:
+            clean_restore = self._restore_user_files()
+            if not clean_restore:
                 return
 
         self._logger.print()


### PR DESCRIPTION
The _restore_user_files function returns False if there was failure and True for success.
The error check was checking for True and returning, thus quitting the linux updater early and not finishing the update if you successfully restored files.