### PR TITLE
Update filter term links in download-filters.md

### DIFF
--- a/docs/download-filters.md
+++ b/docs/download-filters.md
@@ -10,8 +10,8 @@ By default **downloader** will download everything that's available, based on yo
 1. Add a line that starts with `filter =` under the `[mister]` section (if it doesn't exist, just create it).
 1. Then, after `filter =`, add the filter terms themselves.
 
-  - A list of official MiSTer filter terms [is available here](https://github.com/MiSTer-devel/Distribution_MiSTer)
-  - You can also find terms for [Jotego Cores](https://github.com/jotego/jtcores_mister).
+  - A list of official MiSTer filter terms [is available here](https://github.com/MiSTer-devel/Distribution_MiSTer?tab=readme-ov-file#tags-that-you-may-use-with-download-filters-feature)
+  - You can also find terms for [Jotego Cores](https://github.com/jotego/jtcores_mister?tab=readme-ov-file#list-of-tags-that-you-may-use-with-the-downloader-filters).
 
 ### Example
 


### PR DESCRIPTION
Updated links for MiSTer and Jotego Cores filter terms to include specific sections.