### PR TITLE
Fix Windows interpreter selection in PC launcher

### DIFF
--- a/src/pc_launcher.py
+++ b/src/pc_launcher.py
@@ -19,6 +19,7 @@
 
 import os
 import subprocess
+import sys
 from shutil import copy, copyfileobj
 from tempfile import NamedTemporaryFile
 from urllib.request import urlopen
@@ -44,7 +45,7 @@ def fetch_temp_downloader():
 def launch_downloader(filename):
     env = os.environ.copy()
     env['PC_LAUNCHER'] = os.path.realpath(__file__)
-    return subprocess.run(['python3', filename], env=env, stderr=subprocess.STDOUT).returncode
+    return subprocess.run([sys.executable, filename], env=env, stderr=subprocess.STDOUT).returncode
 
 
 def main():


### PR DESCRIPTION
Fixes #58.

The PC launcher currently invokes the downloaded launcher using the hard-coded "python3" command. On Windows, Python may be installed as "python" without a working "python3" command, resulting in "[WinError 2]" or exit code 9009.

This change uses "sys.executable", ensuring the downloaded launcher runs with the same Python interpreter that started the PC launcher.

Validation performed:

- reproduced the failure with the unavailable Windows "python3" alias
- "python -m py_compile src/pc_launcher.py"
- temporary executable-ZIP integration test
- verified "PC_LAUNCHER" propagation
- verified the child launcher ran using the active Python interpreter
- "git diff --check"
- "git diff --cached --check"
- "git show --check HEAD"

No MiSTer hardware validation is required because this affects the cross-platform PC launcher only.
